### PR TITLE
Pass argument to CI agent to skip native libs copy

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -145,7 +145,7 @@ jobs:
         shell: pwsh
 
       - name: Create Nuget package
-        run: msbuild /t:restore,pack /p:Configuration=Release /p:PackageVersion=$env:PACKAGE_VERSION
+        run: msbuild /t:restore,pack /p:SkipNativeLibsCopy=true /p:Configuration=Release /p:PackageVersion=$env:PACKAGE_VERSION
         shell: pwsh
         working-directory: ./dotnet/Library/Okapi
 


### PR DESCRIPTION
Fixes packaging error for MacOS
