### PR TITLE
add oberon to okapi

### DIFF
--- a/include/okapi.h
+++ b/include/okapi.h
@@ -47,6 +47,18 @@ int32_t ldproofs_verify_proof(struct ByteBuffer request,
                               struct ByteBuffer *response,
                               struct ExternError *err);
 
+int32_t oberon_create_token(struct ByteBuffer request,
+                            struct ByteBuffer *response,
+                            struct ExternError *err);
+
+int32_t oberon_create_proof(struct ByteBuffer request,
+                            struct ByteBuffer *response,
+                            struct ExternError *err);
+
+int32_t oberon_verify_proof(struct ByteBuffer request,
+                            struct ByteBuffer *response,
+                            struct ExternError *err);
+
 void didcomm_byte_buffer_free(struct ByteBuffer v);
 
 void didcomm_string_free(char *s);

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -20,6 +20,9 @@ serde_json = "1.0.60"
 serde_jcs = "0.1.0"
 sha2 = { version = "0.9", default-features = false }
 bs58 = "0.3.1"
+oberon = { git = "https://github.com/sethjback/oberon", branch = "fix_proof_bytes" }
+rand = "0.8"
+subtle = "2.4"
 
 [lib]
 name = "okapi"

--- a/native/build.rs
+++ b/native/build.rs
@@ -43,6 +43,7 @@ fn compile_protobuf_files() {
                 "../proto/examples.proto",
                 "../proto/keys.proto",
                 "../proto/proofs.proto",
+                "../proto/security.proto"
             ],
             &["../proto", "../proto/pbmse"],
         )
@@ -52,12 +53,14 @@ fn compile_protobuf_files() {
     copy("okapi.keys.rs", "./src/proto/okapi_keys.rs").unwrap();
     copy("okapi.transport.rs", "./src/proto/okapi_transport.rs").unwrap();
     copy("okapi.proofs.rs", "./src/proto/okapi_proofs.rs").unwrap();
+    copy("okapi.security.rs", "./src/proto/okapi_security.rs").unwrap();
     copy("google.protobuf.rs", "./src/proto/google_protobuf.rs").unwrap();
     copy("pbmse.rs", "./src/proto/pbmse.rs").unwrap();
     remove_file("okapi.examples.rs").unwrap();
     remove_file("okapi.keys.rs").unwrap();
     remove_file("okapi.transport.rs").unwrap();
     remove_file("okapi.proofs.rs").unwrap();
+    remove_file("okapi.security.rs").unwrap();
     remove_file("google.protobuf.rs").unwrap();
     remove_file("pbmse.rs").unwrap();
 }

--- a/native/src/ffi/mod.rs
+++ b/native/src/ffi/mod.rs
@@ -1,4 +1,5 @@
 pub mod didcomm;
 pub mod didkey;
 pub mod ldproofs;
+pub mod oberon;
 pub mod utils;

--- a/native/src/ffi/oberon.rs
+++ b/native/src/ffi/oberon.rs
@@ -1,0 +1,17 @@
+use crate::{proto::security::*, *};
+use ffi_support::{ByteBuffer, ExternError};
+
+#[no_mangle]
+pub extern "C" fn oberon_create_token(request: ByteBuffer, response: &mut ByteBuffer, err: &mut ExternError) -> i32 {
+    c_impl!(CreateOberonTokenRequest, Oberon, token, request, response, err)
+}
+
+#[no_mangle]
+pub extern "C" fn oberon_create_proof(request: ByteBuffer, response: &mut ByteBuffer, err: &mut ExternError) -> i32 {
+    c_impl!(CreateOberonProofRequest, Oberon, proof, request, response, err)
+}
+
+#[no_mangle]
+pub extern "C" fn oberon_verify_proof(request: ByteBuffer, response: &mut ByteBuffer, err: &mut ExternError) -> i32 {
+    c_impl!(VerifyOberonProofRequest, Oberon, verify, request, response, err)
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -5,6 +5,7 @@ use prost::{DecodeError, Message};
 pub struct DIDComm {}
 pub struct DIDKey {}
 pub struct LdProofs {}
+pub struct Oberon {}
 
 #[allow(clippy::ptr_arg)]
 pub trait MessageFormatter {
@@ -42,6 +43,7 @@ mod ffi;
 #[cfg(not(target_arch = "wasm32"))]
 mod jni;
 mod ldproofs;
+mod oberon;
 pub mod proto;
 #[cfg(test)]
 mod tests;

--- a/native/src/oberon/mod.rs
+++ b/native/src/oberon/mod.rs
@@ -1,0 +1,96 @@
+use crate::{proto::security::*, didcomm::Error};
+use std::convert::TryInto;
+use oberon;
+use rand::prelude::*;
+
+impl crate::Oberon{
+    pub fn token<'a>(request: &CreateOberonTokenRequest) -> Result<CreateOberonTokenReply, Error<'a>> {
+        if request.data.len() == 0 {
+            return Err(Error::InvalidField("must provide data"))
+        }
+
+        let skbytes: [u8; oberon::SecretKey::BYTES] = match request.sk.as_slice().try_into() {
+            Ok(skbytes) => skbytes,
+            Err(_) => return Err(Error::InvalidField("invalid secret key provided"))
+        };
+
+        let sk = oberon::SecretKey::from(&skbytes);
+        let mut token = match oberon::Token::new(&sk, &request.data) {
+            None => return Err(Error::InvalidField("invalid data provided")),
+            Some(token) => token
+        };
+
+        let blind_iter = request.blinding.iter();
+        for blind in blind_iter {
+            let b = oberon::Blinding::new(&blind);
+            token = token - b;
+        }
+
+        Ok(CreateOberonTokenReply {
+            token: token.to_bytes().to_vec()
+        })
+    }
+
+    pub fn proof<'a>(request: &CreateOberonProofRequest) -> Result<CreateOberonProofReply, Error<'a>> {
+        if request.data.len() == 0 {
+            return Err(Error::InvalidField("must provide data"))
+        }
+
+        let tokenbytes: [u8; oberon::Token::BYTES] = match request.token.as_slice().try_into() {
+            Ok(tokenbytes) => tokenbytes,
+            Err(_) => return Err(Error::InvalidField("invalid token provided"))
+        };
+
+        let tk = oberon::Token::from_bytes(&tokenbytes);
+        if tk.is_none().into() {
+            return Err(Error::InvalidField("invalid token provided"))
+        }
+        
+        let blinds: Vec<oberon::Blinding> = request.blinding.iter().map(|v|{
+            oberon::Blinding::new(&v)
+        }).collect();
+
+        let mut rng = thread_rng();
+
+        let proof = match oberon::Proof::new(&tk.unwrap(), &blinds, &request.data, &request.nonce, &mut rng) {
+            None => return Err(Error::Unknown),
+            Some(proof) => proof,
+        };
+        
+        Ok(CreateOberonProofReply{
+            proof: proof.to_bytes().to_vec()
+        })
+    }
+
+    pub fn verify<'a>(request: &VerifyOberonProofRequest) -> Result<VerifyOberonProofReply, Error<'a>> {
+        if request.data.len() == 0 {
+            return Err(Error::InvalidField("must provide data"))
+        }
+
+        let pkbytes: [u8; oberon::PublicKey::BYTES] = match request.pk.as_slice().try_into() {
+            Ok(pkbytes) => pkbytes,
+            Err(_) => return Err(Error::InvalidField("invalid public key provided"))
+        };
+
+        let pk = oberon::PublicKey::from_bytes(&pkbytes);
+        if pk.is_none().into() {
+            return Err(Error::InvalidField("invalid public key provided"))
+        }
+        
+        let proofbytes: [u8; oberon::Proof::BYTES] = match request.proof.as_slice().try_into() {
+            Ok(proofbytes) => proofbytes,
+            Err(_) => return Err(Error::InvalidField("invalid proof provided"))
+        };
+        
+        let proof = oberon::Proof::from_bytes(&proofbytes);
+        if proof.is_none().into() {
+            return Err(Error::InvalidField("invalid proof provided"))
+        }
+        
+        let valid = proof.unwrap().open(pk.unwrap(), &*request.data, &request.nonce);
+
+        Ok(VerifyOberonProofReply{
+            valid: valid.into()
+        })
+    }
+}

--- a/native/src/proto/mod.rs
+++ b/native/src/proto/mod.rs
@@ -282,7 +282,11 @@ pub mod transport {
 pub mod proofs {
     pub use crate::proto::okapi_proofs::*;
 }
+pub mod security {
+    pub use crate::proto::okapi_security::*;
+}
 pub mod okapi_keys;
 pub mod okapi_proofs;
 pub mod okapi_transport;
+pub mod okapi_security;
 pub mod pbmse;

--- a/native/src/proto/okapi_security.rs
+++ b/native/src/proto/okapi_security.rs
@@ -1,0 +1,72 @@
+/// Create a new oberon token
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOberonTokenRequest {
+    /// raw BLS key bytes
+    #[prost(bytes="vec", tag="1")]
+    pub sk: ::prost::alloc::vec::Vec<u8>,
+    /// data is the public part of the oberon protocol and can be any data
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// optional blinding for the token
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub blinding: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// Contains the token with optional blinding 
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOberonTokenReply {
+    /// raw token bytes
+    #[prost(bytes="vec", tag="1")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+}
+/// Create a proof that holder knows the token
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOberonProofRequest {
+    /// data used to create the token
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// token data
+    #[prost(bytes="vec", tag="2")]
+    pub token: ::prost::alloc::vec::Vec<u8>,
+    /// any blindings used to create the token
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub blinding: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// nonce for generating the proof
+    #[prost(bytes="vec", tag="4")]
+    pub nonce: ::prost::alloc::vec::Vec<u8>,
+}
+/// Contains the token proof
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOberonProofReply {
+    /// raw proof bytes
+    #[prost(bytes="vec", tag="2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
+}
+/// Verify the presented proof is valid
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VerifyOberonProofRequest {
+    /// raw proof bytes returned from CreateProof
+    #[prost(bytes="vec", tag="1")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
+    /// data used to create the token
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// nonce used to generate the proof
+    #[prost(bytes="vec", tag="3")]
+    pub nonce: ::prost::alloc::vec::Vec<u8>,
+    /// public key that was used to generate the token
+    #[prost(bytes="vec", tag="4")]
+    pub pk: ::prost::alloc::vec::Vec<u8>,
+}
+/// Contains the status of the proof validation
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VerifyOberonProofReply {
+    /// whether the given proof was valid
+    #[prost(bool, tag="1")]
+    pub valid: bool,
+}

--- a/native/src/tests/mod.rs
+++ b/native/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod keys;
 pub mod pack;
 pub mod sign;
+pub mod oberon;

--- a/native/src/tests/oberon.rs
+++ b/native/src/tests/oberon.rs
@@ -1,0 +1,172 @@
+use crate::{didcomm::Error, proto::{security::*}};
+
+
+#[test]
+fn test_create_token() {
+    let req = CreateOberonTokenRequest {
+        sk: vec![1,2,3],
+        data: vec![1,2,3],
+        blinding: Vec::new(),
+    };
+
+
+    let rep = crate::Oberon::token(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("invalid secret key provided")));
+    
+    let req = CreateOberonTokenRequest {
+        sk: vec![
+            16, 133, 126, 11, 192, 153, 22, 14, 53, 214, 99, 40, 66, 194, 96, 30, 19, 86, 137, 107,
+            150, 49, 104, 202, 209, 80, 128, 182, 15, 154, 34, 57, 100, 51, 175, 108, 12, 56, 6,
+            76, 46, 173, 247, 255, 184, 165, 228, 127, 145, 65, 171, 195, 44, 164, 3, 16, 132, 43,
+            108, 82, 63, 136, 116, 3, 93, 1, 226, 152, 197, 152, 61, 212, 185, 32, 195, 211, 37,
+            206, 242, 31, 72, 79, 83, 71, 197, 102, 202, 129, 95, 19, 105, 34, 22, 46, 124, 94
+        ],
+        data: Vec::new(),
+        blinding: Vec::new(),
+    };
+
+    let rep = crate::Oberon::token(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("must provide data")));
+
+    let req = CreateOberonTokenRequest {
+        sk: vec![
+            16, 133, 126, 11, 192, 153, 22, 14, 53, 214, 99, 40, 66, 194, 96, 30, 19, 86, 137, 107,
+            150, 49, 104, 202, 209, 80, 128, 182, 15, 154, 34, 57, 100, 51, 175, 108, 12, 56, 6,
+            76, 46, 173, 247, 255, 184, 165, 228, 127, 145, 65, 171, 195, 44, 164, 3, 16, 132, 43,
+            108, 82, 63, 136, 116, 3, 93, 1, 226, 152, 197, 152, 61, 212, 185, 32, 195, 211, 37,
+            206, 242, 31, 72, 79, 83, 71, 197, 102, 202, 129, 95, 19, 105, 34, 22, 46, 124, 94
+        ],
+        data: "test data to generate tokens".as_bytes().to_vec(),
+        blinding: Vec::new(),
+    };
+
+    let rep = crate::Oberon::token(&req).unwrap();
+    assert_eq!(rep.token,  vec![
+        165, 82, 0, 30, 66, 13, 22, 195, 249, 0, 104, 101, 182, 38, 228, 71, 83, 130, 131, 227,
+        0, 206, 233, 75, 146, 57, 207, 235, 113, 214, 8, 19, 224, 37, 64, 38, 237, 147, 49, 153,
+        45, 215, 100, 113, 209, 75, 204, 65
+        ]);
+    
+    let req = CreateOberonTokenRequest {
+        sk: vec![
+            16, 133, 126, 11, 192, 153, 22, 14, 53, 214, 99, 40, 66, 194, 96, 30, 19, 86, 137, 107,
+            150, 49, 104, 202, 209, 80, 128, 182, 15, 154, 34, 57, 100, 51, 175, 108, 12, 56, 6,
+            76, 46, 173, 247, 255, 184, 165, 228, 127, 145, 65, 171, 195, 44, 164, 3, 16, 132, 43,
+            108, 82, 63, 136, 116, 3, 93, 1, 226, 152, 197, 152, 61, 212, 185, 32, 195, 211, 37,
+            206, 242, 31, 72, 79, 83, 71, 197, 102, 202, 129, 95, 19, 105, 34, 22, 46, 124, 94
+        ],
+        data: "test data to generate tokens".as_bytes().to_vec(),
+        blinding:  vec!["1234".as_bytes().to_vec()],
+    };
+
+    let rep = crate::Oberon::token(&req).unwrap();
+    assert_eq!(rep.token,  vec![
+        128, 239, 129, 168, 211, 193, 253, 149, 210, 3, 37, 224, 181, 244, 67, 
+        164, 128, 148, 40, 79, 106, 146, 15, 185, 128, 197, 131, 34, 239, 232, 48, 219, 
+        20, 248, 143, 172, 162, 39, 65, 117, 204, 67, 237, 24, 122, 86, 196, 73]);
+}
+
+#[test]
+fn test_create_proof() {
+    let req = CreateOberonProofRequest {
+        token: vec![1,2,3],
+        data: vec![1,2,3],
+        nonce: vec![1,2,3],
+        blinding: Vec::new(),
+    };
+
+    let rep = crate::Oberon::proof(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("invalid token provided")));
+
+    let req = CreateOberonProofRequest {
+        token: vec![
+            165, 82, 0, 30, 66, 13, 22, 195, 249, 0, 104, 101, 182, 38, 228, 71, 83, 130, 131, 227,
+            0, 206, 233, 75, 146, 57, 207, 235, 113, 214, 8, 19, 224, 37, 64, 38, 237, 147, 49, 153,
+            45, 215, 100, 113, 209, 75, 204, 65
+        ],
+        data: vec![],
+        nonce: vec![1,2,3],
+        blinding: Vec::new(),
+    };
+
+    let rep = crate::Oberon::proof(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("must provide data")));
+
+    let req = CreateOberonProofRequest {
+        token: vec![
+            165, 82, 0, 30, 66, 13, 22, 195, 249, 0, 104, 101, 182, 38, 228, 71, 83, 130, 131, 227,
+            0, 206, 233, 75, 146, 57, 207, 235, 113, 214, 8, 19, 224, 37, 64, 38, 237, 147, 49, 153,
+            45, 215, 100, 113, 209, 75, 204, 65
+        ],
+        data: b"test data to generate tokens".to_vec(),
+        nonce: b"123456789012345678901234567890".to_vec(),
+        blinding: Vec::new(),
+    };
+
+    let rep = crate::Oberon::proof(&req).unwrap();
+    assert!(rep.proof.len() == 96)
+}
+
+#[test]
+fn test_validate_proof() {
+    let sk = oberon::SecretKey::from_bytes(&[
+        16, 133, 126, 11, 192, 153, 22, 14, 53, 214, 99, 40, 66, 194, 96, 30, 19, 86, 137, 107,
+        150, 49, 104, 202, 209, 80, 128, 182, 15, 154, 34, 57, 100, 51, 175, 108, 12, 56, 6,
+        76, 46, 173, 247, 255, 184, 165, 228, 127, 145, 65, 171, 195, 44, 164, 3, 16, 132, 43,
+        108, 82, 63, 136, 116, 3, 93, 1, 226, 152, 197, 152, 61, 212, 185, 32, 195, 211, 37,
+        206, 242, 31, 72, 79, 83, 71, 197, 102, 202, 129, 95, 19, 105, 34, 22, 46, 124, 94
+    ]).unwrap();
+    let pk = oberon::PublicKey::from(&sk);
+
+    let req = VerifyOberonProofRequest {
+        proof: vec![1,2,3],
+        data: vec![1,2,3],
+        nonce: vec![1,2,3],
+        pk: vec![1,2,3]
+    };
+
+    let rep = crate::Oberon::verify(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("invalid public key provided")));
+    
+    let req = VerifyOberonProofRequest {
+        proof: vec![1,2,3],
+        data: vec![],
+        nonce: vec![1,2,3],
+        pk: pk.to_bytes().to_vec()
+    };
+
+    let rep = crate::Oberon::verify(&req);
+    assert!(matches!(rep.unwrap_err(), Error::InvalidField("must provide data")));
+
+    let req = VerifyOberonProofRequest {
+        proof: vec![
+            148, 26, 138, 47, 5, 101, 166, 140, 15, 231, 239, 156, 37, 104, 58, 76, 41, 99, 93,
+            66, 100, 248, 238, 124, 208, 81, 235, 184, 36, 67, 184, 28, 198, 11, 69, 138, 249, 64,
+            31, 145, 216, 101, 3, 101, 164, 25, 52, 102, 144, 234, 121, 207, 211, 137, 160, 114, 251,
+            73, 38, 9, 207, 93, 52, 55, 10, 174, 114, 99, 147, 123, 224, 6, 88, 47, 44, 12, 149, 22,
+            2, 237, 68, 0, 94, 30, 114, 244, 186, 147, 95, 243, 255, 51, 131, 122, 8, 26
+        ],
+        data: b"test data to generate tokens".to_vec(),
+        nonce: b"123456789012345678901234567890".to_vec(),
+        pk: pk.to_bytes().to_vec()
+    };
+
+    let rep = crate::Oberon::verify(&req).unwrap();
+    assert!(rep.valid == true);
+
+    let req = VerifyOberonProofRequest {
+        proof: vec![
+            148, 26, 138, 47, 5, 101, 166, 140, 15, 231, 239, 156, 37, 104, 58, 76, 41, 99, 93,
+            66, 100, 248, 238, 124, 208, 81, 235, 184, 36, 67, 184, 28, 198, 11, 69, 138, 249, 64,
+            31, 145, 216, 101, 3, 101, 164, 25, 52, 102, 144, 234, 121, 207, 211, 137, 160, 114, 251,
+            73, 38, 9, 207, 93, 52, 55, 10, 174, 114, 99, 147, 123, 224, 6, 88, 47, 44, 12, 149, 22,
+            2, 237, 68, 0, 94, 30, 114, 244, 186, 147, 95, 243, 255, 51, 131, 122, 8, 26
+        ],
+        data: b"test data to generate tokens".to_vec(),
+        nonce: b"asdf".to_vec(),
+        pk: pk.to_bytes().to_vec()
+    };
+
+    let rep = crate::Oberon::verify(&req).unwrap();
+    assert!(rep.valid == false);
+}

--- a/proto/security.proto
+++ b/proto/security.proto
@@ -1,0 +1,48 @@
+// messages related to the oberon protocol
+// See: https://github.com/mikelodder7/oberon
+syntax = "proto3";
+
+package okapi.security;
+
+option csharp_namespace = "Okapi.Security";
+option go_package = "github.com/trinsic-id/okapi";
+option java_package = "trinsic.okapi";
+
+
+// Create a new oberon token
+message CreateOberonTokenRequest {
+    bytes sk = 1; // raw BLS key bytes
+    bytes data = 2; // data is the public part of the oberon protocol and can be any data
+    repeated bytes blinding = 3; // optional blinding for the token
+}
+
+// Contains the token with optional blinding 
+message CreateOberonTokenReply {
+    bytes token = 1; // raw token bytes
+}
+
+// Create a proof that holder knows the token
+message CreateOberonProofRequest {
+    bytes data = 1; // data used to create the token
+    bytes token = 2; // token data
+    repeated bytes blinding = 3; // any blindings used to create the token
+    bytes nonce = 4; // nonce for generating the proof
+}
+
+// Contains the token proof
+message CreateOberonProofReply {
+    bytes proof = 2; // raw proof bytes
+}
+
+// Verify the presented proof is valid
+message VerifyOberonProofRequest {
+    bytes proof = 1; // raw proof bytes returned from CreateProof
+    bytes data = 2; // data used to create the token
+    bytes nonce = 3; // nonce used to generate the proof
+    bytes pk = 4; // public key that was used to generate the token
+}
+
+// Contains the status of the proof validation
+message VerifyOberonProofReply {
+    bool valid = 1; // whether the given proof was valid
+}


### PR DESCRIPTION
This is not ready to merge - we need to open a PR into the upstream oberon library to fix an issue with the `proof::to_bytes` function.

I have submitted it for review in the mean time.