### PR TITLE
Fix artifact flakiness

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs/${{ matrix.os-artifact[1] }}

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -24,6 +24,13 @@ jobs:
           path: ./libs/${{ matrix.os-artifact[1] }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ matrix.os-artifact[1] }}
+      - name: Download C header artifact
+        uses: dawidd6/action-download-artifact@v2.17.0
+        with:
+          workflow: "build-libs.yml"
+          path: ./libs/${{ matrix.os-artifact[1] }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: C_header
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows], [macos-latest, macos] ]
+        os-artifact: [ [ubuntu-latest, linux], [windows-latest, windows-gnu], [macos-latest, macos] ]
     steps:
       - uses: actions/checkout@v2
       - name: Download workflow artifact
@@ -31,7 +31,7 @@ jobs:
           path: ./libs/${{ matrix.os-artifact[1] }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: C_header
-      - name: Set up Go
+      - name: Set up Go (default)
         uses: actions/setup-go@v2
         with:
           go-version: ^1.16
@@ -39,21 +39,26 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Build and Test Golang
+      # Set up Okapi-specific Go runtime. Includes setting GOLANG_LD_PATH env var.
+      - name: Set up Go (Okapi)
         run: |
           go version
           go install golang.org/x/lint/golint@latest
           go install github.com/jstemmer/go-junit-report@latest
           python ../../devops/build_sdks.py
+        shell: pwsh
+        working-directory: go/okapi
+      - name: Build and Test Golang
+        run: |
           go build
           golint
-          go test -v | go-junit-report > test_output.xml
+          go test -v -exec "env DYLD_LIBRARY_PATH=${{ env.GOLANG_LD_PATH }}" | go-junit-report > test_output.xml
         shell: pwsh
         working-directory: go/okapi
         env:
-          LD_LIBRARY_PATH: "${{ github.workspace }}/go/okapi"
-          DYLD_FALLBACK_LIBRARY_PATH: "${{ github.workspace }}/go/okapi"
-          DYLD_LIBRARY_PATH: "${{ github.workspace }}/go/okapi"
+          LD_LIBRARY_PATH: ${{ env.GOLANG_LD_PATH }}
+          DYLD_FALLBACK_LIBRARY_PATH: ${{ env.GOLANG_LD_PATH }}
+          DYLD_LIBRARY_PATH: ${{ env.GOLANG_LD_PATH }}
           API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
       - name: Upload Unit Test Results - Golang
         if: always()

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs/${{ matrix.os-artifact[1] }}

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -34,7 +34,7 @@ jobs:
           cache: 'pip'
             
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs/${{ matrix.os-artifact[1] }}

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'pip'
 
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs/${{ matrix.os-artifact[1] }}

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: "true"
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: '15'
           distribution: 'adopt'
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/.github/workflows/release-libs.yml
+++ b/.github/workflows/release-libs.yml
@@ -10,7 +10,7 @@ jobs:
     name: Upload libs.zip artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: dawidd6/action-download-artifact@v2.14.0
+      - uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           ruby-version: 2.7
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v2.14.0
+        uses: dawidd6/action-download-artifact@v2.17.0
         with:
           workflow: "build-libs.yml"
           path: ./libs

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -206,7 +206,7 @@ def main():
         build_ruby(args)
     if build_all or 'golang' in langs_to_build:
         build_golang(args)
-    if build_all or 'docs' in langs_to_build:
+    if 'docs' in langs_to_build:
         build_java_docs(args)
         build_dotnet_docs(args)
         build_go_docs(args)

--- a/devops/build_sdks.py
+++ b/devops/build_sdks.py
@@ -41,6 +41,13 @@ def get_os_arch_path(extract_dir, windows_path):
     return copy_from
 
 
+
+def set_env_var(name, value):
+    env_file = os.getenv('GITHUB_ENV')
+    with open(env_file, "a") as file:
+        file.write(f"{name}={value}")
+
+
 def copy_okapi_libs(copy_to: str, windows_path='windows'):
     okapi_dir = abspath(join(dirname(__file__), '..'))
     copy_from = get_os_arch_path(okapi_dir, windows_path)
@@ -121,8 +128,10 @@ def build_ruby(args) -> None:
 
 
 def build_golang(args) -> None:
-    # Update version in setup.cfg
+    # Copy in Okapi libraries to the $GOLANG_LD_PATH directory
     golang_dir = abspath(join(get_language_dir('go'), 'okapi'))
+    set_env_var("GOLANG_LD_PATH", golang_dir)
+
     # Copy in the binaries
     copy_okapi_libs(golang_dir, 'windows-gnu')
 

--- a/go/okapi/DidComm.go
+++ b/go/okapi/DidComm.go
@@ -4,6 +4,7 @@ import (
 	"github.com/trinsic-id/okapi/go/okapiproto"
 )
 
+// DidCommer implements the DIDComm Messaging protocol
 type DidCommer interface {
 	Pack(request *okapiproto.PackRequest) (*okapiproto.PackResponse, error)
 	Unpack(request *okapiproto.UnpackRequest) (*okapiproto.UnpackResponse, error)
@@ -11,6 +12,7 @@ type DidCommer interface {
 	Verify(request *okapiproto.VerifyRequest) (*okapiproto.VerifyResponse, error)
 }
 
+// DidComm implements the DIDComm Messaging protocol
 func DidComm() DidCommer {
 	return &didComm{}
 }

--- a/go/okapi/Hashing.go
+++ b/go/okapi/Hashing.go
@@ -4,6 +4,7 @@ import (
 	"github.com/trinsic-id/okapi/go/okapiproto"
 )
 
+// Hasher implements Blake3 and Sha2 hash functions
 type Hasher interface {
 	Sha256Hash(request *okapiproto.SHA256HashRequest) (*okapiproto.SHA256HashResponse, error)
 	Blake3Hash(request *okapiproto.Blake3HashRequest) (*okapiproto.Blake3HashResponse, error)
@@ -11,6 +12,7 @@ type Hasher interface {
 	Blake3DeriveKey(request *okapiproto.Blake3DeriveKeyRequest) (*okapiproto.Blake3DeriveKeyResponse, error)
 }
 
+// Hashing implements Blake3 and Sha2 hash functions
 func Hashing() Hasher {
 	return &hasher{}
 }

--- a/go/okapi/LdProofs.go
+++ b/go/okapi/LdProofs.go
@@ -2,11 +2,13 @@ package okapi
 
 import "github.com/trinsic-id/okapi/go/okapiproto"
 
+// LdProofer implements Linked-Data Proofs
 type LdProofer interface {
 	CreateProof(request *okapiproto.CreateProofRequest) (*okapiproto.CreateProofResponse, error)
 	VerifyProof(request *okapiproto.VerifyProofRequest) (*okapiproto.VerifyProofResponse, error)
 }
 
+// LdProofs implements Linked-Data Proofs
 func LdProofs() LdProofer {
 	return &ldProofs{}
 }

--- a/go/okapi/Oberon.go
+++ b/go/okapi/Oberon.go
@@ -2,6 +2,7 @@ package okapi
 
 import "github.com/trinsic-id/okapi/go/okapiproto"
 
+// Oberoner implements Oberon authentication
 type Oberoner interface {
 	CreateKey(request *okapiproto.CreateOberonKeyRequest) (*okapiproto.CreateOberonKeyResponse, error)
 	CreateToken(request *okapiproto.CreateOberonTokenRequest) (*okapiproto.CreateOberonTokenResponse, error)
@@ -11,6 +12,7 @@ type Oberoner interface {
 	VerifyProof(request *okapiproto.VerifyOberonProofRequest) (*okapiproto.VerifyOberonProofResponse, error)
 }
 
+// Oberon implements Oberon authentication
 func Oberon() Oberoner {
 	return &oberon{}
 }

--- a/go/okapi/native.go
+++ b/go/okapi/native.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 )
 
+// NativeError indicates a native protocol error
 type NativeError struct {
 	Message       string
 	InternalError error
@@ -22,6 +23,7 @@ func (o NativeError) Error() string {
 	return fmt.Sprintf("Error:%s  InternalError:%v", o.Message, o.InternalError)
 }
 
+// DidError indicates a DID protocol error
 type DidError struct {
 	Code         int
 	FunctionName string


### PR DESCRIPTION
I want green checkmarks! :) We should be able to trust these or else real failures will be ignored. 
1. upgrade `dawidd6/action-download-artifact` to 2.17 to address download flakiness ([issue 93](https://github.com/dawidd6/action-download-artifact/issues/93), which was fixed as of 2.14.1)
2. don't build docs by default (seems these always fail)
3. golang:
  a. actually download `C_header` artifact (okapi.h)
  b. set the `GOLANG_LD_PATH` env var.  we need to keep "the place we point LD to" and "the place where we copy lib artifacts to" in sync, so let's set it in `build_sdks.py` and get it in the GitHub workflow. (before this, e.g. on Windows you'd see `GOLANG_LD_PATH=D:\a\okapi\okapi/go/okapi` - wonky slashes!)
  c. use `-exec` to set `DYLD_LIBRARY_PATH` on Mac - see [issue 36572](https://github.com/golang/go/issues/36572)
  d. get lib artifacts for windows-gnu, not windows. seems we're already [trying to do this for golang in build_sdks.py](https://github.com/trinsic-id/okapi/blob/main/devops/build_sdks.py#L127), so the GitHub download workflow should match.  (otherwise, there is no windows-gnu dir to copy from)
  - final nit: add comments to exported interfaces

**Tests**
finally the checkmarks are green and the published XML test reports are all successes!  if you look back through past commits, the XML test reports (especially MacOS and Windows) had usually been failures!