### PR TITLE
Remove need for libokapi.a and okapi.h when building go libraries

### DIFF
--- a/.github/workflows/build-golang.yml
+++ b/.github/workflows/build-golang.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go (default)
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release-golang.yml
+++ b/.github/workflows/release-golang.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   publish_go_tag:
-    name: Tag golnag
+    name: Tag golang
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/btcsuite/btcutil v1.0.2
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,12 +1,16 @@
 module github.com/trinsic-id/okapi/go
 
-go 1.16
+go 1.17
 
 require (
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -9,6 +9,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go/okapi/didcomm.go
+++ b/go/okapi/didcomm.go
@@ -21,24 +21,24 @@ type didComm struct{}
 
 func (d *didComm) Pack(request *okapiproto.PackRequest) (*okapiproto.PackResponse, error) {
 	response := okapiproto.PackResponse{}
-	err := callOkapiNative(request, &response, didcommPack)
+	err := callOkapiNative(request, &response, "didcomm_pack")
 	return &response, err
 }
 
 func (d *didComm) Unpack(request *okapiproto.UnpackRequest) (*okapiproto.UnpackResponse, error) {
 	response := okapiproto.UnpackResponse{}
-	err := callOkapiNative(request, &response, didcommUnpack)
+	err := callOkapiNative(request, &response, "didcomm_unpack")
 	return &response, err
 }
 
 func (d *didComm) Sign(request *okapiproto.SignRequest) (*okapiproto.SignResponse, error) {
 	response := okapiproto.SignResponse{}
-	err := callOkapiNative(request, &response, didcommSign)
+	err := callOkapiNative(request, &response, "didcomm_sign")
 	return &response, err
 }
 
 func (d *didComm) Verify(request *okapiproto.VerifyRequest) (*okapiproto.VerifyResponse, error) {
 	response := okapiproto.VerifyResponse{}
-	err := callOkapiNative(request, &response, didcommVerify)
+	err := callOkapiNative(request, &response, "didcomm_verify")
 	return &response, err
 }

--- a/go/okapi/didkey.go
+++ b/go/okapi/didkey.go
@@ -17,12 +17,12 @@ type didKey struct{}
 
 func (d *didKey) Generate(request *okapiproto.GenerateKeyRequest) (*okapiproto.GenerateKeyResponse, error) {
 	response := okapiproto.GenerateKeyResponse{}
-	err := callOkapiNative(request, &response, didkeyGenerate)
+	err := callOkapiNative(request, &response, "didkey_generate")
 	return &response, err
 }
 
 func (d *didKey) Resolve(request *okapiproto.ResolveRequest) (*okapiproto.ResolveResponse, error) {
 	response := okapiproto.ResolveResponse{}
-	err := callOkapiNative(request, &response, didkeyResolve)
+	err := callOkapiNative(request, &response, "didkey_resolve")
 	return &response, err
 }

--- a/go/okapi/hashing.go
+++ b/go/okapi/hashing.go
@@ -21,24 +21,24 @@ type hasher struct{}
 
 func (h *hasher) Sha256Hash(request *okapiproto.SHA256HashRequest) (*okapiproto.SHA256HashResponse, error) {
 	response := okapiproto.SHA256HashResponse{}
-	err := callOkapiNative(request, &response, sha256Hash)
+	err := callOkapiNative(request, &response, "sha256_hash")
 	return &response, err
 }
 
 func (h *hasher) Blake3Hash(request *okapiproto.Blake3HashRequest) (*okapiproto.Blake3HashResponse, error) {
 	response := okapiproto.Blake3HashResponse{}
-	err := callOkapiNative(request, &response, blake3Hash)
+	err := callOkapiNative(request, &response, "blake3_hash")
 	return &response, err
 }
 
 func (h *hasher) Blake3KeyedHash(request *okapiproto.Blake3KeyedHashRequest) (*okapiproto.Blake3KeyedHashResponse, error) {
 	response := okapiproto.Blake3KeyedHashResponse{}
-	err := callOkapiNative(request, &response, blake3KeyedHash)
+	err := callOkapiNative(request, &response, "blake3_keyed_hash")
 	return &response, err
 }
 
 func (h *hasher) Blake3DeriveKey(request *okapiproto.Blake3DeriveKeyRequest) (*okapiproto.Blake3DeriveKeyResponse, error) {
 	response := okapiproto.Blake3DeriveKeyResponse{}
-	err := callOkapiNative(request, &response, blake3DeriveKey)
+	err := callOkapiNative(request, &response, "blake3_derive_key")
 	return &response, err
 }

--- a/go/okapi/ldproofs.go
+++ b/go/okapi/ldproofs.go
@@ -17,12 +17,12 @@ type ldProofs struct{}
 
 func (l *ldProofs) CreateProof(request *okapiproto.CreateProofRequest) (*okapiproto.CreateProofResponse, error) {
 	response := okapiproto.CreateProofResponse{}
-	err := callOkapiNative(request, &response, ldproofsCreateProof)
+	err := callOkapiNative(request, &response, "ldproofs_create_proof")
 	return &response, err
 }
 
 func (l *ldProofs) VerifyProof(request *okapiproto.VerifyProofRequest) (*okapiproto.VerifyProofResponse, error) {
 	response := okapiproto.VerifyProofResponse{}
-	err := callOkapiNative(request, &response, ldproofsVerifyProof)
+	err := callOkapiNative(request, &response, "ldproofs_verify_proof")
 	return &response, err
 }

--- a/go/okapi/native_call.go
+++ b/go/okapi/native_call.go
@@ -43,7 +43,7 @@ func callOkapiNative(request proto.Message, response proto.Message, funcName str
 		return wrapError("Failed to create buffers", err)
 	}
 	libPtr, funcPtr := getFunctionPointer(funcName)
-	cReqBuf := C.ByteBuffer{len: C.longlong(requestBuffer.len), data: (*C.uchar)(unsafe.Pointer(requestBuffer.data))}
+	cReqBuf := C.ByteBuffer{len: C.int64_t(requestBuffer.len), data: (*C.uchar)(unsafe.Pointer(requestBuffer.data))}
 	cRespBuf := C.ByteBuffer{}
 	cErrBuf := C.ExternError{}
 	errNum := C.okapi_ffi(funcPtr, cReqBuf, &cRespBuf, &cErrBuf)

--- a/go/okapi/native_call.go
+++ b/go/okapi/native_call.go
@@ -8,6 +8,7 @@ import (
 // #cgo LDFLAGS: -ldl
 // #include <dlfcn.h>
 // #include <stdlib.h>
+// #include <stdint.h>
 //
 // typedef struct ByteBuffer {
 //   int64_t len;

--- a/go/okapi/native_call.go
+++ b/go/okapi/native_call.go
@@ -1,0 +1,108 @@
+package okapi
+
+import (
+	"github.com/coreos/pkg/dlopen"
+	"unsafe"
+)
+
+// #cgo LDFLAGS: -ldl
+// #include <dlfcn.h>
+// #include <stdlib.h>
+//
+// typedef struct ByteBuffer {
+//   int64_t len;
+//   uint8_t *data;
+// } ByteBuffer;
+//
+// typedef int32_t ErrorCode;
+//
+// typedef struct ExternError {
+//   ErrorCode code;
+//   char *message;
+// } ExternError;
+//
+// int okapi_ffi(void *func, ByteBuffer requestBuffer, ByteBuffer* responseBuffer, ExternError* errorBuffer)
+// {
+//     typedef int (*okapi_ffi_type)(ByteBuffer requestBuffer, ByteBuffer* responseBuffer, ExternError* errorBuffer);
+//     return ((okapi_ffi_type)func)(requestBuffer, responseBuffer, errorBuffer);
+// }
+//
+// void okapi_bytebuffer_free(void* func, ByteBuffer buf) {
+//     typedef int (*okapi_free_type)(ByteBuffer buffer);
+//     ((okapi_free_type)func)(buf);
+// }
+import "C"
+import (
+	"google.golang.org/protobuf/proto"
+)
+
+func callOkapiNative(request proto.Message, response proto.Message, funcName string) error {
+	requestBuffer, responseBuffer, errorBuffer, err := createBuffersFromMessage(request)
+	if err != nil {
+		return wrapError("Failed to create buffers", err)
+	}
+	libPtr, funcPtr := getFunctionPointer(funcName)
+	cReqBuf := C.ByteBuffer{len: C.longlong(requestBuffer.len), data: (*C.uchar)(unsafe.Pointer(requestBuffer.data))}
+	cRespBuf := C.ByteBuffer{}
+	cErrBuf := C.ExternError{}
+	errNum := C.okapi_ffi(funcPtr, cReqBuf, &cRespBuf, &cErrBuf)
+	defer func(libPtr *dlopen.LibHandle) {
+		err := libPtr.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(libPtr)
+	if errNum != 0 {
+		// Actually check the syscall.Errno to see if it's a real error
+		//  fmt.Sprint("calling function=%s error code=%d", funcName, errNum)
+		return &DidError{Code: int(cErrBuf.code), Message: C.GoString(cErrBuf.message)}
+	}
+	responseBuffer.len = int64(cRespBuf.len)
+	if responseBuffer.len > 0 {
+		responseBuffer.data = &(C.GoBytes(unsafe.Pointer(cRespBuf.data), C.int(cRespBuf.len))[0])
+	}
+	err = cByteBufferFree(cRespBuf)
+	if err != nil {
+		return err
+	}
+	err = unmarshalResponse(responseBuffer, response)
+	if err != nil {
+		return wrapError("Failed to unmarshal response", err)
+	}
+	return createError(errorBuffer)
+}
+
+func getFunctionPointer(funcName string) (*dlopen.LibHandle, unsafe.Pointer) {
+	libPtr, err := dlopen.GetHandle([]string{getLibraryName()})
+	if err != nil {
+		panic(err)
+	}
+	funcPtr, err := libPtr.GetSymbolPointer(funcName)
+	if err != nil {
+		panic(err)
+	}
+	return libPtr, funcPtr
+}
+
+func byteBufferFree(responseBuffer ByteBuffer) error {
+	// We already freed, the C side, we're good.
+	if responseBuffer.len == 0 {
+		// This is just to eliminate the unused warning.
+	}
+	return nil
+}
+
+func cByteBufferFree(cRespBuf C.ByteBuffer) error {
+	funcName := "okapi_bytebuffer_free"
+	libPtr, funcPtr := getFunctionPointer(funcName)
+	defer func(libPtr *dlopen.LibHandle) {
+		err := libPtr.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(libPtr)
+	C.okapi_bytebuffer_free(funcPtr, cRespBuf)
+	//okapiFunc := *(*func(uintptr) int32)(funcPtr)
+	//errNum := okapiFunc(uintptr(unsafe.Pointer(&responseBuffer)))
+	return nil
+}

--- a/go/okapi/native_call_windows.go
+++ b/go/okapi/native_call_windows.go
@@ -1,0 +1,37 @@
+package okapi
+
+import (
+	"google.golang.org/protobuf/proto"
+	"syscall"
+	"unsafe"
+)
+
+func callOkapiNative(request proto.Message, response proto.Message, funcName string) error {
+	requestBuffer, responseBuffer, errorBuffer, err := createBuffersFromMessage(request)
+	if err != nil {
+		return wrapError("Failed to create buffers", err)
+	}
+	dll := syscall.MustLoadDLL(getLibraryName())
+	okapiFunc := dll.MustFindProc(funcName)
+	code, _, err := okapiFunc.Call(uintptr(unsafe.Pointer(&requestBuffer)), uintptr(unsafe.Pointer(&responseBuffer)), uintptr(unsafe.Pointer(&errorBuffer)))
+	if err != syscall.Errno(0x0) {
+		// Actually check the syscall.Errno to see if it's a real error
+		return err
+	}
+	err = unmarshalResponse(responseBuffer, response)
+	if err != nil {
+		return wrapError("Failed to unmarshal response", err)
+	}
+	return createError(int32(code), errorBuffer)
+}
+
+func byteBufferFree(responseBuffer ByteBuffer) error {
+	dll := syscall.MustLoadDLL("okapi.dll")
+	okapiFunc := dll.MustFindProc("okapi_bytebuffer_free")
+	code, _, err := okapiFunc.Call(uintptr(unsafe.Pointer(&responseBuffer)))
+	if err != syscall.Errno(0x0) {
+		// Actually check the syscall.Errno to see if it's a real error
+		return err
+	}
+	return nil
+}

--- a/go/okapi/oberon.go
+++ b/go/okapi/oberon.go
@@ -7,7 +7,7 @@ type Oberoner interface {
 	CreateKey(request *okapiproto.CreateOberonKeyRequest) (*okapiproto.CreateOberonKeyResponse, error)
 	CreateToken(request *okapiproto.CreateOberonTokenRequest) (*okapiproto.CreateOberonTokenResponse, error)
 	BlindToken(request *okapiproto.BlindOberonTokenRequest) (*okapiproto.BlindOberonTokenResponse, error)
-	UnblindToken(request *okapiproto.UnBlindOberonTokenRequest) (*okapiproto.UnBlindOberonTokenResponse, error)
+	UnBlindToken(request *okapiproto.UnBlindOberonTokenRequest) (*okapiproto.UnBlindOberonTokenResponse, error)
 	CreateProof(request *okapiproto.CreateOberonProofRequest) (*okapiproto.CreateOberonProofResponse, error)
 	VerifyProof(request *okapiproto.VerifyOberonProofRequest) (*okapiproto.VerifyOberonProofResponse, error)
 }
@@ -21,36 +21,36 @@ type oberon struct{}
 
 func (d *oberon) CreateKey(request *okapiproto.CreateOberonKeyRequest) (*okapiproto.CreateOberonKeyResponse, error) {
 	response := okapiproto.CreateOberonKeyResponse{}
-	err := callOkapiNative(request, &response, oberonCreateKey)
+	err := callOkapiNative(request, &response, "oberon_create_key")
 	return &response, err
 }
 
 func (d *oberon) CreateToken(request *okapiproto.CreateOberonTokenRequest) (*okapiproto.CreateOberonTokenResponse, error) {
 	response := okapiproto.CreateOberonTokenResponse{}
-	err := callOkapiNative(request, &response, oberonCreateToken)
+	err := callOkapiNative(request, &response, "oberon_create_token")
 	return &response, err
 }
 
 func (d *oberon) BlindToken(request *okapiproto.BlindOberonTokenRequest) (*okapiproto.BlindOberonTokenResponse, error) {
 	response := okapiproto.BlindOberonTokenResponse{}
-	err := callOkapiNative(request, &response, oberonBlindToken)
+	err := callOkapiNative(request, &response, "oberon_blind_token")
 	return &response, err
 }
 
-func (d *oberon) UnblindToken(request *okapiproto.UnBlindOberonTokenRequest) (*okapiproto.UnBlindOberonTokenResponse, error) {
+func (d *oberon) UnBlindToken(request *okapiproto.UnBlindOberonTokenRequest) (*okapiproto.UnBlindOberonTokenResponse, error) {
 	response := okapiproto.UnBlindOberonTokenResponse{}
-	err := callOkapiNative(request, &response, oberonUnBlindToken)
+	err := callOkapiNative(request, &response, "oberon_unblind_token")
 	return &response, err
 }
 
 func (d *oberon) CreateProof(request *okapiproto.CreateOberonProofRequest) (*okapiproto.CreateOberonProofResponse, error) {
 	response := okapiproto.CreateOberonProofResponse{}
-	err := callOkapiNative(request, &response, oberonCreateProof)
+	err := callOkapiNative(request, &response, "oberon_create_proof")
 	return &response, err
 }
 
 func (d *oberon) VerifyProof(request *okapiproto.VerifyOberonProofRequest) (*okapiproto.VerifyOberonProofResponse, error) {
 	response := okapiproto.VerifyOberonProofResponse{}
-	err := callOkapiNative(request, &response, oberonVerifyProof)
+	err := callOkapiNative(request, &response, "oberon_verify_proof")
 	return &response, err
 }

--- a/go/okapi/oberon_test.go
+++ b/go/okapi/oberon_test.go
@@ -51,7 +51,7 @@ func TestDemoWithBlinding(t *testing.T) {
 	// Holder unblinds token
 	unblindRequest := okapiproto.UnBlindOberonTokenRequest{Token: blindedToken.Token}
 	unblindRequest.Blinding = append(unblindRequest.Blinding, issuer2fa)
-	token, _ := ob.UnblindToken(&unblindRequest)
+	token, _ := ob.UnBlindToken(&unblindRequest)
 
 	// Holder prepares a proof without blinding
 	proof, _ := ob.CreateProof(&okapiproto.CreateOberonProofRequest{Data: data, Nonce: nonce, Token: token.Token})


### PR DESCRIPTION
closes #404 - and can throw a library not found error. LOL.
On windows, we use `syscall.LoadDLL` and no CGO required at all. On MacOS and Linux, we use dlopen to find the function pointer which is called from a bit of CGO in the header. This doesn't eliminate the CGO requirement, but eliminates the need to install the `okapi.h` and `libokapi.a` files