### PR TITLE
Switch WASM target to properly build

### DIFF
--- a/devops/BuildLibraries.ps1
+++ b/devops/BuildLibraries.ps1
@@ -108,9 +108,9 @@ try {
         Wasm {
             # https://github.com/rust-lang/rust/issues/41750#issuecomment-312510034
             $env:EMCC_CFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry"
-            rustup target add wasm32-unknown-emscripten
-            cargo build --release --target wasm32-unknown-emscripten
-            Copy-Item -Path .\target\wasm32-unknown-emscripten\release\libokapi.a -Destination $TargetOutput
+            rustup target add wasm32-unknown-unknown
+            cargo build --release --target wasm32-unknown-unknown
+            Copy-Item -Path .\target\wasm32-unknown-unknown\release\libokapi.a -Destination $TargetOutput
             break
         }
     }


### PR DESCRIPTION
https://users.rust-lang.org/t/wasm-unknown-vs-emscripten/22997/5
We should be using `unknown` over `emscripten`