### PR TITLE
V1.6.1 commonjs, node-18 support

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -55,9 +55,9 @@ jobs:
         shell: pwsh
         working-directory: ./wasm/packages/okapi
       - name: "Upload coverage to Codecov"
-        if: ${{ matrix.target }} == 'node'
+        if: {{ ${{ matrix.target }} == 'node' }}
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
-          directory: ./wasm/packages/okapi/.config/coverage
+          directory: ./wasm/packages/okapi
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -60,4 +60,4 @@ jobs:
           fail_ci_if_error: true
           directory: ./wasm/packages/okapi
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.target }} == 'node'
+        if: ${{ matrix.target == 'node' }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -55,6 +55,7 @@ jobs:
         shell: pwsh
         working-directory: ./wasm/packages/okapi
       - name: "Upload coverage to Codecov"
+        if: ${{ matrix.target }} == 'node'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -60,4 +60,4 @@ jobs:
           fail_ci_if_error: true
           directory: ./wasm/packages/okapi
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: "${{ matrix.target }}" == 'node'
+        if: ${{ matrix.target }} == 'node'

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
-          directory: ./wasm/packages/okapi
+          directory: ./wasm/packages/okapi/.config/coverage
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest ]  # windows-latest has issues with wasm-pack.exe
-        node-version: [ 14, 16 ]
+        node-version: [ 14, 16, 18 ]
         target: [ 'node', 'browser' ]
     defaults:
       run:
@@ -50,8 +50,7 @@ jobs:
           rustup toolchain install stable --target wasm32-unknown-unknown
       - run: |
           npm install
-          npm run build:proto
-          npm run build:wasm:${{ matrix.target }}
+          npm run build
           npm run test:${{ matrix.target }}
         shell: pwsh
         working-directory: ./wasm/packages/okapi

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -55,9 +55,9 @@ jobs:
         shell: pwsh
         working-directory: ./wasm/packages/okapi
       - name: "Upload coverage to Codecov"
-        if: {{ ${{ matrix.target }} == 'node' }}
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
           directory: ./wasm/packages/okapi
           token: ${{ secrets.CODECOV_TOKEN }}
+        if: "${{ matrix.target }}" == 'node'

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -35,7 +35,6 @@ jobs:
           rustup toolchain uninstall stable
           rustup toolchain install stable
           rustup toolchain install stable --target wasm32-unknown-unknown
-          npm install -g change-package-name
       - uses: trinsic-id/set-version@v0.1
         id: setversion
         with:
@@ -44,10 +43,10 @@ jobs:
       - run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
       - run: |
           npm install
-          npx change-package-name "@trinsic/okapi-${{ matrix.target }}"
+          npm run rename:${{ matrix.target }}
           npm version ${{ steps.setversion.outputs.packageVersion }} --no-git-tag-version --yes
           npm run build
-          npm run build:${{ matrix.target }}
+          npm run package:${{ matrix.target }}
           npm publish --no-git-tag-version --yes --no-verify-access
         shell: pwsh
         working-directory: ./wasm/packages/okapi

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -14,10 +14,10 @@ jobs:
     name: Publish Npm
     environment:
       name: npmjs.com
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        package-name: [ 'okapi-node', 'okapi-web' ]
+        target: ['node', 'browser' ]
     defaults:
       run:
         working-directory: ./wasm
@@ -44,9 +44,10 @@ jobs:
       - run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
       - run: |
           npm install
-          npx change-package-name "@trinsic/${{ matrix.package-name }}"
+          npx change-package-name "@trinsic/okapi-${{ matrix.target }}"
           npm version ${{ steps.setversion.outputs.packageVersion }} --no-git-tag-version --yes
           npm run build
+          npm run build:${{ matrix.target }}
           npm publish --no-git-tag-version --yes --no-verify-access
         shell: pwsh
         working-directory: ./wasm/packages/okapi

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -15,6 +15,9 @@ jobs:
     environment:
       name: npmjs.com
     runs-on: macos-latest
+    strategy:
+      matrix:
+        package-name: [ 'okapi-node', 'okapi-web' ]
     defaults:
       run:
         working-directory: ./wasm
@@ -32,6 +35,7 @@ jobs:
           rustup toolchain uninstall stable
           rustup toolchain install stable
           rustup toolchain install stable --target wasm32-unknown-unknown
+          npm install -g change-package-name
       - uses: trinsic-id/set-version@v0.1
         id: setversion
         with:
@@ -40,6 +44,7 @@ jobs:
       - run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
       - run: |
           npm install
+          npx change-package-name "@trinsic/${{ matrix.package-name }}"
           npm version ${{ steps.setversion.outputs.packageVersion }} --no-git-tag-version --yes
           npm run build
           npm publish --no-git-tag-version --yes --no-verify-access

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "okapi",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/wasm/packages/okapi/.config/karma.conf.cjs
+++ b/wasm/packages/okapi/.config/karma.conf.cjs
@@ -58,9 +58,6 @@ module.exports = async (config) => {
         webpack: {
             mode: "development",
             devtool: "inline-source-map",
-            entry: {
-                wallet: "../test/web.spec.ts",
-            },
             module: {
                 rules: [
                     {
@@ -68,7 +65,7 @@ module.exports = async (config) => {
                         exclude: /node_modules/,
                         loader: "ts-loader",
                         options: {
-                            configFile: 'tsconfig.json',
+                            configFile: 'tsconfig.web.json',
                         }
                     }
                 ],

--- a/wasm/packages/okapi/README.md
+++ b/wasm/packages/okapi/README.md
@@ -2,3 +2,4 @@
 * [Install wasm pack](https://rustwasm.github.io/wasm-pack/book/quickstart.html)
 * On windows you may have to replace the local `wasm-pack.exe` due to a version conflict.
   * From the download above, replace `./node_modules/binary-install/bin/wasm-pack.exe` with the version in `C:/users/[name]/.cargo/wasm-pack.exe`
+* We publish two NPM packages from this source code: `@trinsic-id/okapi-node` and `@trinsic-id/okapi-web`. We rename the package from `@trinsic-id/okapi` to each of these names at release time.

--- a/wasm/packages/okapi/package.json
+++ b/wasm/packages/okapi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trinsic/okapi",
+  "name": "@trinsic/okapi-node",
   "version": "1.0.0",
   "description": "Okapi native binaries wrapper for node and web.",
   "browser": {
@@ -14,13 +14,15 @@
   "scripts": {
     "build": "npm run build:proto && npm run build:wasm",
     "build:proto": "pwsh ./Generate-Proto.ps1",
-    "build:node": "npx tsc -p tsconfig.json && copyfiles -u 1 src/native_node/* ./lib",
-    "build:browser": "npx tsc -p tsconfig.web.json && copyfiles -u 1 src/native_browser/* ./lib",
     "build:wasm": "npm run build:wasm:node && npm run build:wasm:browser",
     "build:wasm:node": "npx wasm-pack build --target nodejs --out-dir packages/okapi/src/native_node && npm run build:clean",
     "build:wasm:browser": "npx wasm-pack build --target bundler --out-dir packages/okapi/src/native_browser && npm run build:clean",
     "build:clean": "rimraf ./src/native_*/package.json ./src/native_*/README.md ./src/native_*/.gitignore ./src/native_*/LICENSE",
     "clean:all": "rimraf ./src/native_*",
+    "package:node": "npx tsc -p tsconfig.json && copyfiles -u 1 src/native_node/* ./lib",
+    "package:browser": "npx tsc -p tsconfig.web.json && copyfiles -u 1 src/native_browser/* ./lib",
+    "rename:node": "npx change-package-name @trinsic/okapi-node",
+    "rename:browser": "npx change-package-name @trinsic/okapi-web",
     "test:node": "jest --config .config/jest.config.cjs",
     "test:browser": "karma start .config/karma.conf.cjs"
   },

--- a/wasm/packages/okapi/package.json
+++ b/wasm/packages/okapi/package.json
@@ -12,9 +12,10 @@
     "lib/*"
   ],
   "scripts": {
-    "build": "npm run build:proto && npm run build:wasm && npm run build:node",
+    "build": "npm run build:proto && npm run build:wasm",
     "build:proto": "pwsh ./Generate-Proto.ps1",
-    "build:node": "npx tsc -p tsconfig.json && copyfiles -u 1 src/native_*/* ./lib",
+    "build:node": "npx tsc -p tsconfig.json && copyfiles -u 1 src/native_node/* ./lib",
+    "build:browser": "npx tsc -p tsconfig.web.json && copyfiles -u 1 src/native_browser/* ./lib",
     "build:wasm": "npm run build:wasm:node && npm run build:wasm:browser",
     "build:wasm:node": "npx wasm-pack build --target nodejs --out-dir packages/okapi/src/native_node && npm run build:clean",
     "build:wasm:browser": "npx wasm-pack build --target bundler --out-dir packages/okapi/src/native_browser && npm run build:clean",

--- a/wasm/packages/okapi/package.json
+++ b/wasm/packages/okapi/package.json
@@ -42,7 +42,8 @@
   "license": "ISC",
   "dependencies": {
     "google-protobuf": "^3.20.1",
-    "long": "^5.2.0"
+    "long": "^5.2.0",
+    "protobufjs": "^6.11.3"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.15.6",

--- a/wasm/packages/okapi/tsconfig.json
+++ b/wasm/packages/okapi/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
+    "target": "ES2017",
+    "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,

--- a/wasm/packages/okapi/tsconfig.web.json
+++ b/wasm/packages/okapi/tsconfig.web.json
@@ -1,0 +1,10 @@
+{
+  "extends": "tsconfig.json",
+  "compilerOptions": {
+    "module": "es2020",
+  },
+  "include": [
+    "./src/index.ts"
+  ],
+  "exclude": ["node_modules", "lib", "test", "src/native_node"]
+}

--- a/wasm/packages/okapi/tsconfig.web.json
+++ b/wasm/packages/okapi/tsconfig.web.json
@@ -1,10 +1,7 @@
 {
-  "extends": "tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "es2020",
   },
-  "include": [
-    "./src/index.ts"
-  ],
   "exclude": ["node_modules", "lib", "test", "src/native_node"]
 }


### PR DESCRIPTION
Do not merge until all tests pass, and the `rc` also works manually. @fundthmcalculus will verify independently as it pertains to `okapi-examples` and `sdk` directly. Once that works, we can merge.