### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-/.github/   @fundthmcalculus @tmarkovski
-/dotnet/    @tmarkovski
-/go/        @fundthmcalculus
-/java/      @fundthmcalculus
-/native/    @tmarkovski
-/proto/     @fundthmcalculus @tmarkovski
-/python/    @fundthmcalculus
-/ruby/      @fundthmcalculus
-/wasm/      @tmarkovski


### PR DESCRIPTION
This simply blocks other people from approving PRs. Anyone should have the context to review a PR and approve it.