### PR TITLE
fix path okapi lookup linux

### DIFF
--- a/go/okapi/native.go
+++ b/go/okapi/native.go
@@ -90,6 +90,9 @@ func getLibraryCheckPaths() []string {
 			path.Join("/usr/local/lib", libName),
 		)
 	}
+	if runtime.GOOS == "linux" {
+		checkPaths = append(checkPaths, path.Join("/usr/local/lib", libName))	
+	}
 	return checkPaths
 }
 


### PR DESCRIPTION
When I run the okapi instructions on my cicd:

```
wget https://github.com/trinsic-id/okapi/releases/download/v${OKAPI_VERSION}/okapi_${OKAPI_VERSION}_amd64.deb;
sudo dpkg -i okapi_${OKAPI_VERSION}_amd64.deb; 
```

the tests fail to find the okapi dep. 

The fix: 
I appended to the lookup path on linux /usr/local/lib for OKAPI_LIBRARY_PATH. Manually, setting OKAPI_LIBRARY_PATH also fixes this, but is not a long term fix and hurts adoption. 

Logs: 

**Failure logs before fix**
```
could not find necessary okapi binary. paths searched:
libokapi.so
linux/libokapi.so
libokapi.so
linux/libokapi.so
libokapi.so
libokapi.socould not find necessary okapi binary. paths searched:
libokapi.so
linux/libokapi.so
libokapi.so
linux/libokapi.so
libokapi.so
```

Over commands (github actions):

```
      - name: Install okapi from trinsic
        run: |
          wget https://github.com/trinsic-id/okapi/releases/download/v${OKAPI_VERSION}/okapi_${OKAPI_VERSION}_amd64.deb;
          sudo dpkg -i okapi_${OKAPI_VERSION}_amd64.deb;
        env:
          OKAPI_VERSION: 1.6.0

      - name: Test Everything
        run: mage citest
        env:
          LD_LIBRARY_PATH: "/usr/local/lib"
```