### PR TITLE
Temporarily remove building mac-catalyst targets to enable pipelines

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -110,10 +110,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: "true"
-      - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+      # - name: Setup Xcode version
+      #   uses: maxim-lobanov/setup-xcode@v1
+      #   with:
+      #     xcode-version: latest-stable
       - name: Run build script
         run: ./devops/BuildLibraries.ps1 -Platform MacOS -OutLocation ./libs/macos
         shell: pwsh

--- a/devops/BuildLibraries.ps1
+++ b/devops/BuildLibraries.ps1
@@ -84,12 +84,12 @@ try {
             cargo build --release --target x86_64-apple-ios
             cargo build --release --target aarch64-apple-ios
 
-            cargo +nightly build --release -Z build-std --target x86_64-apple-ios-macabi
-            cargo +nightly build --release -Z build-std --target aarch64-apple-ios-macabi
+            # cargo +nightly build --release -Z build-std --target x86_64-apple-ios-macabi
+            # cargo +nightly build --release -Z build-std --target aarch64-apple-ios-macabi
 
             # Create the fat binaries, cargo-lipo doesn't support ios sim aarch64
             lipo -create "./target/x86_64-apple-ios/release/libokapi.a" "./target/aarch64-apple-ios-sim/release/libokapi.a" -output "$TargetOutput/libokapi_simulator.a"
-            lipo -create "./target/x86_64-apple-ios-macabi/release/libokapi.a" "./target/aarch64-apple-ios-macabi/release/libokapi.a" -output "$TargetOutput/libokapi_maccatalyst.a"
+            # lipo -create "./target/x86_64-apple-ios-macabi/release/libokapi.a" "./target/aarch64-apple-ios-macabi/release/libokapi.a" -output "$TargetOutput/libokapi_maccatalyst.a"
             Copy-Item -Path "./target/aarch64-apple-ios/release/libokapi.a" -Destination "$TargetOutput/libokapi.a"
             break
         }


### PR DESCRIPTION
Due to [upstream bug in cc-rs](https://github.com/rust-lang/cc-rs/pull/678), mac catalyst rust targets are failing to build. This PR removes the building of these targets until fix is in.